### PR TITLE
new: added libarg.Parse which parse args without configs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ '*', '*/*' ]
+
+jobs:
+
+  build:
+    name: Test for Go ${{ matrix.gover }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gover: ['~1.18', '~1.19', '~1.20']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.gover }}
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -cover ./...

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ This library supports Go 1.18 or later.
 ### Actual test results for each Go version:
 
 ```
+% gvm-fav
+Now using version go1.18.10
+go version go1.18.10 darwin/amd64
+ok  	github.com/sttk-go/clidax/libarg	0.131s	coverage: 100.0% of statements
+
+Now using version go1.19.5
+go version go1.19.5 darwin/amd64
+ok  	github.com/sttk-go/clidax/libarg	0.135s	coverage: 100.0% of statements
+
+Now using version go1.20
+go version go1.20 darwin/amd64
+ok  	github.com/sttk-go/clidax/libarg	0.137s	coverage: 100.0% of statements
+
+Back to go1.20
+Now using version go1.20
+%
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module github.com/sttk-go/clidax
 
 go 1.20
+
+require (
+	github.com/stretchr/testify v1.8.0
+	github.com/sttk-go/sabi v0.2.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/sttk-go/sabi v0.2.0 h1:eXyNcUmv54Kg3BIUOdrk3jNCXvFLp/MEvQriI1NBOwI=
+github.com/sttk-go/sabi v0.2.0/go.mod h1:YcP+oW3jRInzYmFIKXt32gnfAX5PewyNmkCZSbpEo7A=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/libarg/doc.go
+++ b/libarg/doc.go
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+/*
+Package github.com/sttk-go/clidax/libarg is a library to parse command line arguments for Golang application.
+*/
+package libarg

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -1,0 +1,189 @@
+package libarg
+
+import (
+	"github.com/sttk-go/sabi"
+	"os"
+	"strings"
+	"unicode"
+)
+
+type /* error reason */ (
+	// InvalidOption is an error reason which indicates that an invalid option is
+	// found in command line arguments.
+	InvalidOption struct{ Option string }
+)
+
+var (
+	empty            = make([]string, 0)
+	rangeOfAlphabets = &unicode.RangeTable{
+		R16: []unicode.Range16{
+			{0x0041, 0x005a, 1}, // A-Z
+			{0x0061, 0x007a, 1}, // a-z
+		},
+	}
+	rangeOfAlNumMarks = &unicode.RangeTable{
+		R16: []unicode.Range16{
+			{0x002d, 0x002d, 1}, // -
+			{0x0030, 0x0039, 1}, // 0-9
+			{0x0041, 0x005a, 1}, // A-Z
+			{0x0061, 0x007a, 1}, // a-z
+		},
+	}
+)
+
+// Args is a structure which contains command parameters and option parameters
+// that are parsed from command line arguments without configurations.
+// And this provides methods to check if they are specified or to obtain them.
+type Args struct {
+	optParams map[string][]string
+	cmdParams []string
+}
+
+// HasOpt is a method which checks if the option is specified in command line
+// arguments.
+func (args Args) HasOpt(opt string) bool {
+	return args.optParams[opt] != nil
+}
+
+// OptParam is a method to get a option parameter which is firstly specified
+// with opt in command line arguments.
+func (args Args) OptParam(opt string) string {
+	arr := args.optParams[opt]
+	if len(arr) > 0 {
+		return arr[0]
+	} else {
+		return ""
+	}
+}
+
+// OptParams is a method to get option parameters which are all specified with
+// opt in command line arguments.
+func (args Args) OptParams(opt string) []string {
+	arr := args.optParams[opt]
+	if len(arr) > 0 {
+		return arr
+	} else {
+		return empty
+	}
+}
+
+// CmdParams is a method to get command parameters which are specified in
+// command line parameters and are not associated with any options.
+func (args Args) CmdParams() []string {
+	return args.cmdParams
+}
+
+// Parse is a function to parse command line arguments without configurations.
+// This function divides command line arguments to command parameters, which
+// are not associated with any options, and options, of which each has a name
+// and option parametes.
+// If an option appears multiple times in command line arguments, the option
+// has multiple option parameters.
+// Options are divided to long format options and short format options.
+//
+// A long format option starts with "--" and follows multiple characters which
+// consists of alphabets, numbers, and '-'.
+// (A character immediately after the heading "--" allows only an alphabet.)
+// A long format option can be followed by "=" and its option parameter.
+//
+// A short format option starts with "-" and follows single character which is
+// an alphabet.
+// Multiple short options can be combined into one argument.
+// (For example -a -b -c can be combined into -abc.)
+// Moreover, a short option can be followed by "=" and its option parameter.
+// In case of combined short options, only the last short option can take an
+// option parameter.
+// (For example, -abc=3 is equal to -a -b -c=3.)
+//
+//	os.Args[1:]               // [--foo-bar=A -a --baz -bc=3 qux]
+//	args, _ := Parse()
+//	args.HasOpt("a")          // true
+//	args.HasOpt("b")          // true
+//	args.HasOpt("c")          // true
+//	args.HasOpt("foo-bar")    // true
+//	args.HasOpt("baz")        // true
+//	args.OptParam("foo-bar")  // A
+//	args.OptParams("foo-bar") // [A]
+//	args.OptParam("c")        // 3
+//	args.OptParams("c")       // [3]
+//	args.CmdParams()          // [qux]
+func Parse() (Args, sabi.Err) {
+	var args Args
+
+	var cmdParams = make([]string, 0)
+	var optParams = make(map[string][]string)
+
+	isNonOpt := false
+
+	for _, arg := range os.Args[1:] {
+		if isNonOpt {
+			cmdParams = append(cmdParams, arg)
+
+		} else if arg == "--" {
+			isNonOpt = true
+
+		} else if strings.HasPrefix(arg, "--") {
+			arg = arg[2:]
+			i := 0
+			for _, r := range arg {
+				if i > 0 {
+					if r == '=' {
+						break
+					}
+					if !unicode.Is(rangeOfAlNumMarks, r) {
+						return args, sabi.NewErr(InvalidOption{Option: arg})
+					}
+				} else {
+					if !unicode.Is(rangeOfAlphabets, r) {
+						return args, sabi.NewErr(InvalidOption{Option: arg})
+					}
+				}
+				i++
+			}
+			if i == len(arg) {
+				addKeyToMap(optParams, arg)
+			} else {
+				addKeyValueToMap(optParams, arg[0:i], arg[i+1:])
+			}
+
+		} else if strings.HasPrefix(arg, "-") {
+			arg := arg[1:]
+			var last string
+			for i, r := range arg {
+				if i > 0 && r == '=' {
+					addKeyValueToMap(optParams, last, arg[i+1:])
+					break
+				}
+				last = string(r)
+				if !unicode.Is(rangeOfAlphabets, r) {
+					return args, sabi.NewErr(InvalidOption{Option: last})
+				}
+				addKeyToMap(optParams, last)
+			}
+
+		} else {
+			cmdParams = append(cmdParams, arg)
+		}
+	}
+
+	args.cmdParams = cmdParams
+	args.optParams = optParams
+
+	return args, sabi.Ok()
+}
+
+func addKeyToMap(m map[string][]string, key string) {
+	arr := m[key]
+	if arr == nil {
+		m[key] = empty
+	}
+}
+
+func addKeyValueToMap(m map[string][]string, key, val string) {
+	arr := m[key]
+	if arr == nil {
+		m[key] = []string{val}
+	} else {
+		m[key] = append(arr, val)
+	}
+}

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -1,0 +1,376 @@
+package libarg_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/clidax/libarg"
+	"os"
+	"testing"
+)
+
+var osArgs []string = os.Args
+
+func resetArgs() {
+	os.Args = osArgs
+}
+
+func TestParse_zeroArg(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 1)
+	os.Args[0] = osArgs[0]
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneNonOptArg(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "abcd"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, args.CmdParams(), []string{"abcd"})
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneLongOpt(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "--silent"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.True(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string{})
+}
+
+func TestParse_oneLongOptWithParam(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "--alphabet=ABC"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.True(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "ABC")
+	assert.Equal(t, args.OptParams("alphabet"), []string{"ABC"})
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneShortOpt(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-s"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneShortOptWithParam(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-a=123"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "123")
+	assert.Equal(t, args.OptParams("a"), []string{"123"})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-sa"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string{})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-sa=123"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "123")
+	assert.Equal(t, args.OptParams("a"), []string{"123"})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "--aaa-bbb-ccc=123"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("aaa-bbb-ccc"))
+	assert.Equal(t, args.OptParam("aaa-bbb-ccc"), "123")
+	assert.Equal(t, args.OptParams("aaa-bbb-ccc"), []string{"123"})
+}
+
+func TestParse_optParamsIncludesEqualMark(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-sa=b=c"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "b=c")
+	assert.Equal(t, args.OptParams("a"), []string{"b=c"})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_optParamsIncludesMarks(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-sa=1,2-3"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "1,2-3")
+	assert.Equal(t, args.OptParams("a"), []string{"1,2-3"})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 4)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-s"
+	os.Args[2] = "--abc%def"
+	os.Args[3] = "-a"
+
+	args, err := libarg.Parse()
+
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.InvalidOption:
+		assert.Equal(t, err.Get("Option"), "abc%def")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "--1abc"
+
+	args, err := libarg.Parse()
+
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.InvalidOption:
+		assert.Equal(t, err.Get("Option"), "1abc")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "---aaa=123"
+
+	args, err := libarg.Parse()
+
+	switch err.Reason().(type) {
+	case libarg.InvalidOption:
+		assert.Equal(t, err.Get("Option"), "-aaa=123")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_IllegalCharInShortOpt(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 4)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-s"
+	os.Args[2] = "--alphabet"
+	os.Args[3] = "-s@"
+
+	args, err := libarg.Parse()
+
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.InvalidOption:
+		assert.Equal(t, err.Get("Option"), "@")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.False(t, args.HasOpt("s"))
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_useEndOptMark(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 7)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-s"
+	os.Args[2] = "--"
+	os.Args[3] = "-s"
+	os.Args[4] = "--"
+	os.Args[5] = "-s@"
+	os.Args[6] = "xxx"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, args.CmdParams(), []string{"-s", "--", "-s@", "xxx"})
+	assert.False(t, args.HasOpt("a"))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+}
+
+func TestParse_multipleArgs(t *testing.T) {
+	defer resetArgs()
+
+	os.Args = make([]string, 11)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "--alphabet=ABC"
+	os.Args[2] = "-a=123"
+	os.Args[3] = "--a=456"
+	os.Args[4] = "xxxx"
+	os.Args[5] = "--silent"
+	os.Args[6] = "--alphabet"
+	os.Args[7] = "-sa=789"
+	os.Args[8] = "yyy"
+	os.Args[9] = "--alphabet=DEF"
+	os.Args[10] = "zz"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, args.CmdParams(), []string{"xxxx", "yyy", "zz"})
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "123")
+	assert.Equal(t, args.OptParams("a"), []string{"123", "456", "789"})
+	assert.True(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "ABC")
+	assert.Equal(t, args.OptParams("alphabet"), []string{"ABC", "DEF"})
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.True(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string{})
+}


### PR DESCRIPTION
### Changes

- [new: added libarg.Parse which parse args without configs](https://github.com/sttk-go/clidax/commit/04ee3c42ab0b4ef7eb34528689b535e63dad11bb)

    This commit adds `Parse` function in `github.com/sttk-go/clidax/libarg` package.
    This function will be used in `CliDax`.

- [doc: added actual test results for each go version](https://github.com/sttk-go/clidax/commit/aa5d94db35dc340f7baaff590b6e6079a19b8c5b)

    This commit adds the description about actual test results in local environment for each go version in `README.md`. 

- [cicd: added github actions config file](https://github.com/sttk-go/clidax/commit/185b3ac46736fc6aa12825808756e31ceefa8c3e)

    This commit adds `.github/workflow/go.yml` which is a github actions configuration file for go applications.