### PR TITLE
fix!: renamed an error reason, distinguished nil slice and empty slice, etc.

### DIFF
--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -8,9 +8,9 @@ import (
 )
 
 type /* error reason */ (
-	// InvalidOption is an error reason which indicates that an invalid option is
-	// found in command line arguments.
-	InvalidOption struct{ Option string }
+	// OptionHasInvalidChar is an error reason which indicates that an invalid
+  // character is found in the option.
+	OptionHasInvalidChar struct{ Option string }
 )
 
 var (
@@ -173,11 +173,11 @@ func parseArgs(
 						break
 					}
 					if !unicode.Is(rangeOfAlNumMarks, r) {
-						return sabi.NewErr(InvalidOption{Option: arg})
+						return sabi.NewErr(OptionHasInvalidChar{Option: arg})
 					}
 				} else {
 					if !unicode.Is(rangeOfAlphabets, r) {
-						return sabi.NewErr(InvalidOption{Option: arg})
+						return sabi.NewErr(OptionHasInvalidChar{Option: arg})
 					}
 				}
 				i++
@@ -210,7 +210,7 @@ func parseArgs(
 				}
 				opt = string(r)
 				if !unicode.Is(rangeOfAlphabets, r) {
-					return sabi.NewErr(InvalidOption{Option: opt})
+					return sabi.NewErr(OptionHasInvalidChar{Option: opt})
 				}
 				err := collectOptParams(opt)
 				if !err.IsOk() {

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -14,6 +14,7 @@ type /* error reason */ (
 )
 
 var (
+	//noentry []string = nil
 	empty            = make([]string, 0)
 	rangeOfAlphabets = &unicode.RangeTable{
 		R16: []unicode.Range16{
@@ -42,29 +43,28 @@ type Args struct {
 // HasOpt is a method which checks if the option is specified in command line
 // arguments.
 func (a Args) HasOpt(opt string) bool {
-	return a.optParams[opt] != nil
+	_, exists := a.optParams[opt]
+	return exists
 }
 
 // OptParam is a method to get a option parameter which is firstly specified
 // with opt in command line arguments.
 func (a Args) OptParam(opt string) string {
 	arr := a.optParams[opt]
-	if len(arr) > 0 {
-		return arr[0]
-	} else {
+	// If no entry, map returns a nil slice.
+	// If a value of a found entry is an empty slice.
+	// Both returned values are zero length in common.
+	if len(arr) == 0 {
 		return ""
+	} else {
+		return arr[0]
 	}
 }
 
 // OptParams is a method to get option parameters which are all specified with
 // opt in command line arguments.
 func (a Args) OptParams(opt string) []string {
-	arr := a.optParams[opt]
-	if len(arr) > 0 {
-		return arr
-	} else {
-		return empty
-	}
+	return a.optParams[opt]
 }
 
 // CmdParams is a method to get command parameters which are specified in
@@ -118,8 +118,8 @@ func Parse() (Args, sabi.Err) {
 		return sabi.Ok()
 	}
 	var collOptParams = func(opt string, params ...string) sabi.Err {
-		arr := optParams[opt]
-		if arr == nil {
+		arr, exists := optParams[opt]
+		if !exists {
 			arr = empty
 		}
 		optParams[opt] = append(arr, params...)

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -9,7 +9,7 @@ import (
 
 type /* error reason */ (
 	// OptionHasInvalidChar is an error reason which indicates that an invalid
-  // character is found in the option.
+	// character is found in the option.
 	OptionHasInvalidChar struct{ Option string }
 )
 
@@ -42,15 +42,15 @@ type Args struct {
 
 // HasOpt is a method which checks if the option is specified in command line
 // arguments.
-func (a Args) HasOpt(opt string) bool {
-	_, exists := a.optParams[opt]
+func (args Args) HasOpt(opt string) bool {
+	_, exists := args.optParams[opt]
 	return exists
 }
 
 // OptParam is a method to get a option parameter which is firstly specified
 // with opt in command line arguments.
-func (a Args) OptParam(opt string) string {
-	arr := a.optParams[opt]
+func (args Args) OptParam(opt string) string {
+	arr := args.optParams[opt]
 	// If no entry, map returns a nil slice.
 	// If a value of a found entry is an empty slice.
 	// Both returned values are zero length in common.
@@ -63,14 +63,14 @@ func (a Args) OptParam(opt string) string {
 
 // OptParams is a method to get option parameters which are all specified with
 // opt in command line arguments.
-func (a Args) OptParams(opt string) []string {
-	return a.optParams[opt]
+func (args Args) OptParams(opt string) []string {
+	return args.optParams[opt]
 }
 
 // CmdParams is a method to get command parameters which are specified in
 // command line parameters and are not associated with any options.
-func (a Args) CmdParams() []string {
-	return a.cmdParams
+func (args Args) CmdParams() []string {
+	return args.cmdParams
 }
 
 // Parse is a function to parse command line arguments without configurations.
@@ -98,17 +98,17 @@ func (a Args) CmdParams() []string {
 // Usage example:
 //
 //	// os.Args[1:]  ==>  [--foo-bar=A -a --baz -bc=3 qux]
-//	a, _ := Parse()
-//	a.HasOpt("a")          // true
-//	a.HasOpt("b")          // true
-//	a.HasOpt("c")          // true
-//	a.HasOpt("foo-bar")    // true
-//	a.HasOpt("baz")        // true
-//	a.OptParam("foo-bar")  // A
-//	a.OptParams("foo-bar") // [A]
-//	a.OptParam("c")        // 3
-//	a.OptParams("c")       // [3]
-//	a.CmdParams()          // [qux]
+//	args, _ := Parse()
+//	args.HasOpt("a")          // true
+//	args.HasOpt("b")          // true
+//	args.HasOpt("c")          // true
+//	args.HasOpt("foo-bar")    // true
+//	args.HasOpt("baz")        // true
+//	args.OptParam("foo-bar")  // A
+//	args.OptParams("foo-bar") // [A]
+//	args.OptParam("c")        // 3
+//	args.OptParams("c")       // [3]
+//	args.CmdParams()          // [qux]
 func Parse() (Args, sabi.Err) {
 	var cmdParams = make([]string, 0)
 	var optParams = make(map[string][]string)

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -235,7 +235,7 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
-	case libarg.InvalidOption:
+	case libarg.OptionHasInvalidChar:
 		assert.Equal(t, err.Get("Option"), "abc%def")
 	default:
 		assert.Fail(t, err.Error())
@@ -258,7 +258,7 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
-	case libarg.InvalidOption:
+	case libarg.OptionHasInvalidChar:
 		assert.Equal(t, err.Get("Option"), "1abc")
 	default:
 		assert.Fail(t, err.Error())
@@ -280,7 +280,7 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	args, err := libarg.Parse()
 
 	switch err.Reason().(type) {
-	case libarg.InvalidOption:
+	case libarg.OptionHasInvalidChar:
 		assert.Equal(t, err.Get("Option"), "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
@@ -305,7 +305,7 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
-	case libarg.InvalidOption:
+	case libarg.OptionHasInvalidChar:
 		assert.Equal(t, err.Get("Option"), "@")
 	default:
 		assert.Fail(t, err.Error())

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -9,12 +9,12 @@ import (
 
 var osArgs []string = os.Args
 
-func resetArgs() {
+func resetOsArgs() {
 	os.Args = osArgs
 }
 
 func TestParse_zeroArg(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 1)
 	os.Args[0] = osArgs[0]
@@ -30,7 +30,7 @@ func TestParse_zeroArg(t *testing.T) {
 }
 
 func TestParse_oneNonOptArg(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -47,7 +47,7 @@ func TestParse_oneNonOptArg(t *testing.T) {
 }
 
 func TestParse_oneLongOpt(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -66,7 +66,7 @@ func TestParse_oneLongOpt(t *testing.T) {
 }
 
 func TestParse_oneLongOptWithParam(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -85,7 +85,7 @@ func TestParse_oneLongOptWithParam(t *testing.T) {
 }
 
 func TestParse_oneShortOpt(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -104,7 +104,7 @@ func TestParse_oneShortOpt(t *testing.T) {
 }
 
 func TestParse_oneShortOptWithParam(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -123,7 +123,7 @@ func TestParse_oneShortOptWithParam(t *testing.T) {
 }
 
 func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -144,7 +144,7 @@ func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
 }
 
 func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -165,7 +165,7 @@ func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
 }
 
 func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -181,7 +181,7 @@ func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
 }
 
 func TestParse_optParamsIncludesEqualMark(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -202,7 +202,7 @@ func TestParse_optParamsIncludesEqualMark(t *testing.T) {
 }
 
 func TestParse_optParamsIncludesMarks(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -223,7 +223,7 @@ func TestParse_optParamsIncludesMarks(t *testing.T) {
 }
 
 func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 4)
 	os.Args[0] = osArgs[0]
@@ -248,7 +248,7 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 }
 
 func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -271,7 +271,7 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 }
 
 func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
 	os.Args[0] = osArgs[0]
@@ -293,7 +293,7 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 }
 
 func TestParse_IllegalCharInShortOpt(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 4)
 	os.Args[0] = osArgs[0]
@@ -318,7 +318,7 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 }
 
 func TestParse_useEndOptMark(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 7)
 	os.Args[0] = osArgs[0]
@@ -342,7 +342,7 @@ func TestParse_useEndOptMark(t *testing.T) {
 }
 
 func TestParse_multipleArgs(t *testing.T) {
-	defer resetArgs()
+	defer resetOsArgs()
 
 	os.Args = make([]string, 11)
 	os.Args[0] = osArgs[0]


### PR DESCRIPTION
### Changes:

1. [test: renamed a function: resetArgs -> resetOsArgs](https://github.com/sttk-go/clidax/commit/6c85be43e272ee4807598ed5b9bde131fe96aefb)

    This modification just renames `resetArgs` function to `resetOsArgs` in test code.

3. [fix: distinguished nil slice and empty slice](https://github.com/sttk-go/clidax/commit/4763cf7c1b0dd21e8676b995e9bcce447936935a)

    I didn't understand golang's nil slice and empty slice. Both of them are zero length, but are different at the point of the result of comparison to `nil`. In addition, `map` of which value is slice returns nil slice if no entry (as the first returned value and exisitence flag as the second returned value).

   This modification changes to that:

    1. `args.HasOpt` method uses the second returned value of `map[key]`.
    2. `args.OptParam` method uses the length of the returned slice to check whether the method can return the first option parameter.
    3. `args.OptParams` method returns the result of `map[key]` as it is. If a option is not in command line arguments, the method returns a nil string slice.

4. [fix!: renamed an error reason: InvalidOption -> OptionHasInvalidChar](https://github.com/sttk-go/clidax/commit/d34b5e60fdafa5a56b067b94173437f32fb6b74d)

    This modification renames an error reason: `InvalidOption` to `OptionHasInvalidChar`. Its fields is not changed.

5. [update: renamed receivers: a -> args](https://github.com/sttk-go/clidax/commit/4f6e35bd27f385f5d55cd9c79987dc458219ed2f)

    This modification changes receiver names of `Args`'s methods from `a` to `args`.