### PR TITLE
new: added a new function: ParseWith, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,43 @@ A dax of sabi to operate command line interface of Golang application.
 - [License](#license)
 
 <a name="usage"></a>
-## Usage
+## Usage examples
 
 ### Parse CLI arguments without configurations
 
+```
+// os.Args[1:]  ==>  [--foo-bar=A -a --baz -bc=3 qux]
+args, _ := Parse()
+args.HasOpt("a")          // true
+args.HasOpt("b")          // true
+args.HasOpt("c")          // true
+args.HasOpt("foo-bar")    // true
+args.HasOpt("baz")        // true
+args.OptParam("foo-bar")  // A
+args.OptParams("foo-bar") // [A]
+args.OptParam("c")        // 3
+args.OptParams("c")       // [3]
+args.CmdParams()          // [qux]
+```
 
 ### Parse CLI arguments with configurations
 
+```
+osArgs := []string{"--foo-bar", "quz", "--baz", "1", "-z=2", "-X", "quux"}
+optCfgs := []OptCfg{
+  OptCfg{Name:"foo-bar"},
+  OptCfg{Name:"baz", Aliases:[]string{"z"}, HasParam:true, IsArray:true},
+  OptCfg{Name:"*"},
+}
+
+args, err := ParseWith(osArgs, optCfgs)
+args.HasOpt("foo-bar")  // true
+args.HasOpt("baz")      // true
+args.HasOpt("X")        // true, due to "*" config
+args.OptParam("baz")    // 1
+args.OptParams("baz")   // [1 2]
+args.CmdParams()        // [qux quux]
+```
 
 ### Parse CLI arguments with struct tags
 

--- a/libarg/parse-with.go
+++ b/libarg/parse-with.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package libarg
+
+import (
+	"github.com/sttk-go/sabi"
+)
+
+type /* error reason */ (
+	// ConfigIsArrayButHasNoParam is an error reason which indicates that
+	// an option configuration contradicts that the option must be an array
+	// (.IsArray = true) but must have no option parameter (.HasParam = false).
+	ConfigIsArrayButHasNoParam struct{ Opt string }
+
+	// UnconfiguredOption is an error reason which indicates that there is no
+	// configuration about the input option.
+	UnconfiguredOption struct{ Opt string }
+
+	// OptionNeedsParam is an error reason which indicates that an option is
+	// input with no option parameter though its option configuration requires
+	// option parameters (.HasParam = true).
+	OptionNeedsParam struct{ Opt string }
+
+	// OptionTakesNoParam is an error reason which indicates that an option is
+	// input with an option parameter though its option configuration does not
+	// accept option parameters (.HasParam = false).
+	OptionTakesNoParam struct{ Opt string }
+
+	// OptionIsNotArray is an error reason which indicates that an option is
+	// input with an option parameter multiple times though its option
+	// configuration specifies the option is not an array (.IsArray = false).
+	OptionIsNotArray struct{ Opt string }
+)
+
+const anyOpt = "*"
+
+// OptCfg is a structure that represents an option configuration.
+// An option configuration consists of fields: Name, Aliases, HasParam,
+// IsArray.
+
+// Name is the option name and Aliases are the another names.
+// Options given by those names in command line arguments are all registered to
+// Args with the Name.
+// HasParam and IsArray are flags which allows the option to take option
+// parameters.
+// If both HasParam and IsArray are true, the option can take one or multiple
+// option parameters.
+// If HasParam is true and IsArray is false, the option can take only one
+// option parameter.
+// If both HasParam and IsArray are false, the option can take no option
+// parameter.
+type OptCfg struct {
+	Name     string
+	Aliases  []string
+	HasParam bool
+	IsArray  bool
+}
+
+// ParseWith is a function which parses command line arguments with option
+// configurations.
+// This function divides command line arguments to command parameters and
+// options, and an option consists of a name and option parameters.
+// Options are divided to long format options and short format options.
+// About long/short format options, since they are same with Parse function,
+// see the comment of the function.
+//
+// This function allows only options declared in option configurations.
+// A option configuration has fields: Name, Aliases, HasParam, and IsArray.
+// When an option matches Name or includes in Aliases in an option
+// configuration, the option is registered in Args with the Name.
+// If both HasParam and IsArray are true, the option can has one or multiple
+// option parameters, and if HasParam is true and IsArray is false, the option
+// can has only one option parameter, otherwise the option cannot have option
+// parameter.
+//
+// If options not declared in option configurations are given in command line
+// arguments, this function basically returns UnconfiguredOption error.
+// If you want to allow other options, add an option configuration of which
+// Name is "*" (but HasParam and IsArray of this configuration is ignored).
+//
+// Usage example:
+//
+//	osArgs := []string{"--foo-bar", "quz", "--baz", "1", "-z=2", "-X", "quux"}
+//	optCfgs := []OptCfg{
+//	  OptCfg{Name:"foo-bar"},
+//	  OptCfg{Name:"baz", Aliases:[]string{"z"}, HasParam:true, IsArray:true},
+//	  OptCfg{Name:"*"},
+//	}
+//
+//	args, err := ParseWith(osArgs, optCfgs)
+//	args.HasOpt("foo-bar")  // true
+//	args.HasOpt("baz")      // true
+//	args.HasOpt("X")        // true, due to "*" config
+//	args.OptParam("baz")    // 1
+//	args.OptParams("baz")   // [1 2]
+//	args.CmdParams()        // [qux quux]
+func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
+	hasAnyOpt := false
+	cfgMap := make(map[string]int)
+	for i, cfg := range optCfgs {
+		if cfg.IsArray && !cfg.HasParam {
+			err := sabi.NewErr(ConfigIsArrayButHasNoParam{Opt: cfg.Name})
+			return Args{cmdParams: empty}, err
+		}
+		if cfg.Name == anyOpt {
+			hasAnyOpt = true
+			continue
+		}
+		cfgMap[cfg.Name] = i
+		for _, a := range cfg.Aliases {
+			cfgMap[a] = i
+		}
+	}
+
+	var takeParam = func(opt string) bool {
+		i, exists := cfgMap[opt]
+		if exists {
+			return optCfgs[i].HasParam
+		}
+		return false
+	}
+
+	var cmdParams = make([]string, 0)
+	var optParams = make(map[string][]string)
+
+	var collCmdParams = func(params ...string) sabi.Err {
+		cmdParams = append(cmdParams, params...)
+		return sabi.Ok()
+	}
+	var collOptParams = func(opt string, params ...string) sabi.Err {
+		i, exists := cfgMap[opt]
+		if !exists {
+			if !hasAnyOpt {
+				return sabi.NewErr(UnconfiguredOption{Opt: opt})
+			}
+
+			arr := optParams[opt]
+			if arr == nil {
+				arr = empty
+			}
+			optParams[opt] = append(arr, params...)
+			return sabi.Ok()
+		}
+
+		cfg := optCfgs[i]
+		if !cfg.HasParam {
+			if len(params) > 0 {
+				return sabi.NewErr(OptionTakesNoParam{Opt: cfg.Name})
+			}
+		} else {
+			if len(params) == 0 {
+				return sabi.NewErr(OptionNeedsParam{Opt: cfg.Name})
+			}
+		}
+
+		arr := optParams[cfg.Name]
+		if arr == nil {
+			arr = empty
+		}
+		arr = append(arr, params...)
+
+		if !cfg.IsArray {
+			if len(arr) > 1 {
+				return sabi.NewErr(OptionIsNotArray{Opt: cfg.Name})
+			}
+		}
+
+		optParams[cfg.Name] = arr
+		return sabi.Ok()
+	}
+
+	err := parseArgs(args, collCmdParams, collOptParams, takeParam)
+	if !err.IsOk() {
+		return Args{cmdParams: empty}, err
+	}
+
+	return Args{cmdParams: cmdParams, optParams: optParams}, err
+}

--- a/libarg/parse-with_test.go
+++ b/libarg/parse-with_test.go
@@ -1,0 +1,767 @@
+package libarg_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/clidax/libarg"
+	"testing"
+)
+
+func TestParseWith_zeroCfgAndZeroArg(t *testing.T) {
+	optCfgs := []libarg.OptCfg{}
+
+	osArgs := []string{}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_zeroCfgAndOneCommandParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{}
+
+	osArgs := []string{"foo-bar"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{"foo-bar"})
+}
+
+func testParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{}
+
+	osArgs := []string{"--foo-bar"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.UnconfiguredOption:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{}
+
+	osArgs := []string{"-f"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.UnconfiguredOption:
+		assert.Equal(t, err.Get("Opt"), "f")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgAndZeroOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+	}
+
+	osArgs := []string{}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgAndOneCmdParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+	}
+
+	osArgs := []string{"foo-bar"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{"foo-bar"})
+}
+
+func TestParseWith_oneCfgAndOneLongOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+	}
+
+	osArgs := []string{"--foo-bar"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgAndOneShortOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f"},
+	}
+
+	osArgs := []string{"-f"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string{})
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+	}
+
+	osArgs := []string{"--boo-far"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.UnconfiguredOption:
+		assert.Equal(t, err.Get("Opt"), "boo-far")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f"},
+	}
+
+	osArgs := []string{"-b"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.UnconfiguredOption:
+		assert.Equal(t, err.Get("Opt"), "b")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_anyOptCfgAndOneDifferentLongOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+		libarg.OptCfg{Name: "*"},
+	}
+
+	osArgs := []string{"--boo-far"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	assert.True(t, args.HasOpt("boo-far"))
+	assert.Equal(t, args.OptParam("boo-far"), "")
+	assert.Equal(t, args.OptParams("boo-far"), []string{})
+}
+
+func TestParseWith_anyOptCfgAndOneDifferentShortOpt(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f"},
+		libarg.OptCfg{Name: "*"},
+	}
+
+	osArgs := []string{"-b"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	assert.True(t, args.HasOpt("b"))
+	assert.Equal(t, args.OptParam("b"), "")
+	assert.Equal(t, args.OptParams("b"), []string{})
+}
+
+func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar", HasParam: true},
+	}
+
+	osArgs := []string{"--foo-bar", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar", ""}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar="}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f", HasParam: true},
+	}
+
+	osArgs := []string{"-f", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "ABC")
+	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "ABC")
+	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f", ""}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string{""})
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f="}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string{""})
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasParamButOneLongOptHasNoParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar", HasParam: true},
+	}
+
+	osArgs := []string{"--foo-bar"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionNeedsParam:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasParamAndOneShortOptHasNoParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f", HasParam: true},
+	}
+
+	osArgs := []string{"-f"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionNeedsParam:
+		assert.Equal(t, err.Get("Opt"), "f")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+	}
+
+	osArgs := []string{"--foo-bar", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{"ABC"})
+
+	osArgs = []string{"--foo-bar=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionTakesNoParam:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar", ""}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{""})
+
+	osArgs = []string{"--foo-bar="}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionTakesNoParam:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "f"},
+	}
+
+	osArgs := []string{"-f", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string{})
+	assert.Equal(t, args.CmdParams(), []string{"ABC"})
+
+	osArgs = []string{"-f=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionTakesNoParam:
+		assert.Equal(t, err.Get("Opt"), "f")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f", ""}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string{})
+	assert.Equal(t, args.CmdParams(), []string{""})
+
+	osArgs = []string{"-f="}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionTakesNoParam:
+		assert.Equal(t, err.Get("Opt"), "f")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasNoParamButIsArray(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar", HasParam: false, IsArray: true},
+	}
+
+	osArgs := []string{"--foo-bar", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.ConfigIsArrayButHasNoParam:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar", HasParam: true, IsArray: true},
+		libarg.OptCfg{Name: "f", HasParam: true, IsArray: true},
+	}
+
+	osArgs := []string{"--foo-bar", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar", "ABC", "--foo-bar=DEF"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f", "ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "ABC")
+	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f", "ABC", "-f=DEF"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.True(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "ABC")
+	assert.Equal(t, args.OptParams("f"), []string{"ABC", "DEF"})
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{
+			Name:     "foo-bar",
+			Aliases:  []string{"f", "b"},
+			HasParam: true,
+		},
+	}
+
+	osArgs := []string{"--foo-bar", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"--foo-bar=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{
+			Name:     "foo-bar",
+			Aliases:  []string{"f"},
+			HasParam: true,
+		},
+	}
+
+	osArgs := []string{"-f", "ABC"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f=ABC"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{
+			Name:     "foo-bar",
+			Aliases:  []string{"f"},
+			HasParam: true,
+			IsArray:  true,
+		},
+	}
+
+	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+
+	osArgs = []string{"-f=ABC", "--foo-bar", "DEF"}
+
+	args, err = libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{
+			Name:     "foo-bar",
+			Aliases:  []string{"f"},
+			HasParam: true,
+			IsArray:  false,
+		},
+	}
+
+	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.OptionIsNotArray:
+		assert.Equal(t, err.Get("Opt"), "foo-bar")
+	default:
+		assert.Fail(t, err.Error())
+	}
+	assert.False(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
+	assert.False(t, args.HasOpt("f"))
+	assert.Equal(t, args.OptParam("f"), "")
+	assert.Equal(t, args.OptParams("f"), []string(nil))
+	assert.Equal(t, args.CmdParams(), []string{})
+}
+
+func TestParseWith_multipleArgs(t *testing.T) {
+	osArgs := []string{"--foo-bar", "qux", "--baz", "1", "-z=2", "-X", "quux"}
+	optCfgs := []libarg.OptCfg{
+		libarg.OptCfg{Name: "foo-bar"},
+		libarg.OptCfg{
+			Name:     "baz",
+			Aliases:  []string{"z"},
+			HasParam: true,
+			IsArray:  true,
+		},
+		libarg.OptCfg{Name: "*"},
+	}
+
+	args, err := libarg.ParseWith(osArgs, optCfgs)
+	assert.True(t, err.IsOk())
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.True(t, args.HasOpt("baz"))
+	assert.True(t, args.HasOpt("X"))
+	assert.Equal(t, args.OptParam("baz"), "1")
+	assert.Equal(t, args.OptParams("baz"), []string{"1", "2"})
+	assert.Equal(t, args.CmdParams(), []string{"qux", "quux"})
+}

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -80,7 +80,7 @@ func (args Args) CmdParams() []string {
 // Parse is a function to parse command line arguments without configurations.
 // This function divides command line arguments to command parameters, which
 // are not associated with any options, and options, of which each has a name
-// and option parametes.
+// and option parameters.
 // If an option appears multiple times in command line arguments, the option
 // has multiple option parameters.
 // Options are divided to long format options and short format options.
@@ -101,18 +101,16 @@ func (args Args) CmdParams() []string {
 //
 // Usage example:
 //
-//	// os.Args[1:]  ==>  [--foo-bar=A -a --baz -bc=3 qux]
+//	// os.Args[1:]  ==>  [--foo-bar=A -a --baz -bc=3 qux -c=4 quux]
 //	args, _ := Parse()
 //	args.HasOpt("a")          // true
 //	args.HasOpt("b")          // true
 //	args.HasOpt("c")          // true
 //	args.HasOpt("foo-bar")    // true
 //	args.HasOpt("baz")        // true
-//	args.OptParam("foo-bar")  // A
-//	args.OptParams("foo-bar") // [A]
 //	args.OptParam("c")        // 3
-//	args.OptParams("c")       // [3]
-//	args.CmdParams()          // [qux]
+//	args.OptParams("c")       // [3 4]
+//	args.CmdParams()          // [qux quux]
 func Parse() (Args, sabi.Err) {
 	var cmdParams = make([]string, 0)
 	var optParams = make(map[string][]string)

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -128,7 +128,7 @@ func Parse() (Args, sabi.Err) {
 
 	err := parseArgs(os.Args[1:], collCmdParams, collOptParams, _false)
 	if !err.IsOk() {
-		return Args{}, err
+		return Args{cmdParams: empty}, err
 	}
 
 	return Args{cmdParams: cmdParams, optParams: optParams}, err

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -154,8 +154,6 @@ func parseArgs(
 			if !err.IsOk() {
 				return err
 			}
-		} else if arg == "--" {
-			isNonOpt = true
 
 		} else if len(prevOptTakingParams) > 0 {
 			err := collectOptParams(prevOptTakingParams, arg)
@@ -165,6 +163,10 @@ func parseArgs(
 			prevOptTakingParams = ""
 
 		} else if strings.HasPrefix(arg, "--") {
+			if len(arg) == 2 {
+				isNonOpt = true
+				continue
+			}
 			arg = arg[2:]
 			i := 0
 			for _, r := range arg {
@@ -197,6 +199,13 @@ func parseArgs(
 				}
 			}
 		} else if strings.HasPrefix(arg, "-") {
+			if len(arg) == 1 {
+				err := collectCmdParams(arg)
+				if !err.IsOk() {
+					return err
+				}
+				continue
+			}
 			arg := arg[1:]
 			var opt string
 			i := 0

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -1,3 +1,7 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
 package libarg
 
 import (

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -474,33 +474,33 @@ func TestParse_singleHyphen(t *testing.T) {
 func TestParse_multipleArgs(t *testing.T) {
 	defer resetOsArgs()
 
-	os.Args = make([]string, 11)
+	os.Args = make([]string, 8)
 	os.Args[0] = osArgs[0]
-	os.Args[1] = "--alphabet=ABC"
-	os.Args[2] = "-a=123"
-	os.Args[3] = "--a=456"
-	os.Args[4] = "xxxx"
-	os.Args[5] = "--silent"
-	os.Args[6] = "--alphabet"
-	os.Args[7] = "-sa=789"
-	os.Args[8] = "yyy"
-	os.Args[9] = "--alphabet=DEF"
-	os.Args[10] = "zz"
+	os.Args[1] = "--foo-bar"
+	os.Args[2] = "-a"
+	os.Args[3] = "--baz"
+	os.Args[4] = "-bc=3"
+	os.Args[5] = "qux"
+	os.Args[6] = "-c=4"
+	os.Args[7] = "quux"
 
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, args.CmdParams(), []string{"xxxx", "yyy", "zz"})
 	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "123")
-	assert.Equal(t, args.OptParams("a"), []string{"123", "456", "789"})
-	assert.True(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "ABC")
-	assert.Equal(t, args.OptParams("alphabet"), []string{"ABC", "DEF"})
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.True(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string{})
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string{})
+	assert.True(t, args.HasOpt("b"))
+	assert.Equal(t, args.OptParam("b"), "")
+	assert.Equal(t, args.OptParams("b"), []string{})
+	assert.True(t, args.HasOpt("c"))
+	assert.Equal(t, args.OptParam("c"), "3")
+	assert.Equal(t, args.OptParams("c"), []string{"3", "4"})
+	assert.True(t, args.HasOpt("foo-bar"))
+	assert.Equal(t, args.OptParam("foo-bar"), "")
+	assert.Equal(t, args.OptParams("foo-bar"), []string{})
+	assert.True(t, args.HasOpt("baz"))
+	assert.Equal(t, args.OptParam("baz"), "")
+	assert.Equal(t, args.OptParams("baz"), []string{})
+	assert.Equal(t, args.CmdParams(), []string{"qux", "quux"})
 }

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -22,11 +22,19 @@ func TestParse_zeroArg(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneNonOptArg(t *testing.T) {
@@ -41,9 +49,17 @@ func TestParse_oneNonOptArg(t *testing.T) {
 	assert.True(t, err.IsOk())
 	assert.Equal(t, args.CmdParams(), []string{"abcd"})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneLongOpt(t *testing.T) {
@@ -56,10 +72,16 @@ func TestParse_oneLongOpt(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.True(t, args.HasOpt("silent"))
 	assert.Equal(t, args.OptParam("silent"), "")
 	assert.Equal(t, args.OptParams("silent"), []string{})
@@ -75,13 +97,19 @@ func TestParse_oneLongOptWithParam(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.True(t, args.HasOpt("alphabet"))
 	assert.Equal(t, args.OptParam("alphabet"), "ABC")
 	assert.Equal(t, args.OptParams("alphabet"), []string{"ABC"})
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneShortOpt(t *testing.T) {
@@ -94,13 +122,19 @@ func TestParse_oneShortOpt(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneShortOptWithParam(t *testing.T) {
@@ -113,13 +147,19 @@ func TestParse_oneShortOptWithParam(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "123")
 	assert.Equal(t, args.OptParams("a"), []string{"123"})
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
@@ -141,6 +181,21 @@ func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string{})
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
+	assert.True(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
@@ -153,15 +208,19 @@ func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "123")
 	assert.Equal(t, args.OptParams("a"), []string{"123"})
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
@@ -190,15 +249,19 @@ func TestParse_optParamsIncludesEqualMark(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "b=c")
 	assert.Equal(t, args.OptParams("a"), []string{"b=c"})
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_optParamsIncludesMarks(t *testing.T) {
@@ -211,15 +274,19 @@ func TestParse_optParamsIncludesMarks(t *testing.T) {
 	args, err := libarg.Parse()
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "1,2-3")
 	assert.Equal(t, args.OptParams("a"), []string{"1,2-3"})
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
@@ -240,11 +307,19 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
@@ -263,11 +338,19 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
@@ -285,11 +368,19 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_IllegalCharInShortOpt(t *testing.T) {
@@ -310,11 +401,19 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, len(args.CmdParams()), 0)
+	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_useEndOptMark(t *testing.T) {
@@ -334,11 +433,17 @@ func TestParse_useEndOptMark(t *testing.T) {
 	assert.True(t, err.IsOk())
 	assert.Equal(t, args.CmdParams(), []string{"-s", "--", "-s@", "xxx"})
 	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
 	assert.Equal(t, args.OptParam("s"), "")
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
 func TestParse_multipleArgs(t *testing.T) {

--- a/libarg/parse_test.go
+++ b/libarg/parse_test.go
@@ -446,6 +446,31 @@ func TestParse_useEndOptMark(t *testing.T) {
 	assert.Equal(t, args.OptParams("silent"), []string(nil))
 }
 
+func TestParse_singleHyphen(t *testing.T) {
+	defer resetOsArgs()
+
+	os.Args = make([]string, 2)
+	os.Args[0] = osArgs[0]
+	os.Args[1] = "-"
+
+	args, err := libarg.Parse()
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, args.CmdParams(), []string{"-"})
+	assert.False(t, args.HasOpt("a"))
+	assert.Equal(t, args.OptParam("a"), "")
+	assert.Equal(t, args.OptParams("a"), []string(nil))
+	assert.False(t, args.HasOpt("alphabet"))
+	assert.Equal(t, args.OptParam("alphabet"), "")
+	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
+	assert.False(t, args.HasOpt("s"))
+	assert.Equal(t, args.OptParam("s"), "")
+	assert.Equal(t, args.OptParams("s"), []string(nil))
+	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, args.OptParam("silent"), "")
+	assert.Equal(t, args.OptParams("silent"), []string(nil))
+}
+
 func TestParse_multipleArgs(t *testing.T) {
 	defer resetOsArgs()
 


### PR DESCRIPTION
### Changes:

1. [fix: modified to set an empty slice to Args.cmdParams if an error occured](https://github.com/sttk-go/clidax/commit/c44aadd07d509473ec369ca8842aeb7acec7756e)

    This modification makes that `Args.cmdParams` is always an empty slice.

2. [fix: modified operations for "--" and "-"](https://github.com/sttk-go/clidax/commit/f9ed7e1e1068b8600ca3601f5096bc8bf71994d5)

    This modification is a bug fix for `--` and `-`.

3. [fix: modified operation for options which takes parameters](https://github.com/sttk-go/clidax/commit/40605ecf4996b48d6ff25f47cc017d5260cb86cf)

    This modification is a bug fix for the case that an option takes a parameter but no argument follows it. 

4. [comment: added the file header to parse.go](https://github.com/sttk-go/clidax/commit/6e21e3e7221edb9056d39ab83c815d418be72dac)

    This modification adds the file header comment to `parse.go`.

5. [new: added a new function: ParseWith](https://github.com/sttk-go/clidax/commit/1464820f3ff6ed10dfdd9571c1a96b5a4756edf8)

    This modification adds a function `ParseWith` which parses command line arguments according with option configurations.
