### PR TITLE
new: added a new function: ParseFor, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ args.CmdParams()        // [qux quux]
 
 ### Parse CLI arguments with struct tags
 
+```
+type MyOptions struct {
+  FooBar bool     `opt:"foo-bar,f"`
+  Baz    int      `opt:"baz,b=99"`
+  Qux    string   `opt:"=XXX"`
+  Quux   []string `opt:"quux=/[A/B/C]"`
+  Corge  []int
+}
+options := MyOptions{}
+
+osArgs := []string{
+  "--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+  "--Corge", "20", "--Corge=21",
+}
+
+cmdParams, err := ParseFor(osArgs, &options)
+cmdParams      // [c1 c2]
+options.FooBar // true
+options.Baz    // 12
+options.Qux    // ABC
+options.Quux   // [A B C]
+options.Corge  // [20 21]
+```
 
 <a name="support-go-versions"></a>
 ## Supporting Go versions
@@ -59,15 +82,15 @@ This library supports Go 1.18 or later.
 % gvm-fav
 Now using version go1.18.10
 go version go1.18.10 darwin/amd64
-ok  	github.com/sttk-go/clidax/libarg	0.133s	coverage: 96.6% of statements
+ok  	github.com/sttk-go/clidax/libarg	0.131s	coverage: 97.0% of statements
 
 Now using version go1.19.5
 go version go1.19.5 darwin/amd64
-ok  	github.com/sttk-go/clidax/libarg	0.135s	coverage: 96.6% of statements
+ok  	github.com/sttk-go/clidax/libarg	0.133s	coverage: 97.0% of statements
 
 Now using version go1.20
 go version go1.20 darwin/amd64
-ok  	github.com/sttk-go/clidax/libarg	0.137s	coverage: 96.6% of statements
+ok  	github.com/sttk-go/clidax/libarg	0.137s	coverage: 97.0% of statements
 
 Back to go1.20
 Now using version go1.20

--- a/libarg/parse-for.go
+++ b/libarg/parse-for.go
@@ -1,0 +1,492 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package libarg
+
+import (
+	"github.com/sttk-go/sabi"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type /* error reason */ (
+	// OptionStoreIsNotChangeable is an error reason which indicates that
+	// the second parameter of ParseFor function, which is set options produced
+	// by parsing command line arguments, is not a pointer.
+	OptionStoreIsNotChangeable struct{}
+
+	// FailToParseInt is an error reaason which indicates that an option
+	// parameter in command line arguments should be an integer but is invalid.
+	FailToParseInt struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// FailToParseUint is an error reason which indicates that an option
+	// parameter in command line arguments should be an unsigned integer but is
+	// invalid.
+	FailToParseUint struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// FailToParseFloat is an error reason which indicates that an option
+	// parameter in command line arguments should be a floating point number but
+	// is invalid.
+	FailToParseFloat struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// IllegalOptionType is an error reason which indicates that a type of a
+	// field of the option store is neither a boolean, a number, a string, nor
+	// an array of numbers or strings.
+	IllegalOptionType struct {
+		Field string
+		Type  reflect.Type
+	}
+)
+
+// ParseFor is a function to parse command line arguments and set their values
+// to the option store which is the second parameter of this function.
+// This function divides command line arguments to command parameters and
+// options, then stores the options to the option store, and returns the
+// command parameters.
+//
+// The configurations of options are determined by types and struct tags of
+// fields of the option store.
+// If the type is bool, the option takes no parameter.
+// If the type is integer, floating point number or string, the option can
+// takes one  option parameter, therefore it can appear once in command line
+// arguments.
+// If the type is an array, the option can takes multiple option parameters,
+// therefore it can appear multiple times in command line arguments.
+//
+// A struct tag can specify an option name, aliases, and a default value.
+// It has a special format, like `opt:foo-bar,f=123`.
+// This opt: is the struct tag key for the option configuration.
+// The string following this key and rounded by double quotes is the content
+// of the option configuration.
+// The first part of the option configuration is an option name and aliases,
+// which are separated by commas, and ends with "=" mark or end of string.
+// If the option name is empty or no struct tag, the option's name becomes same
+// with the field name of the option store.
+//
+// The string after the "=" mark is default value(s).
+// If the type of the option is a boolean, the string after "=" mark is ignored
+// because a boolean option takes no option parameter.
+// If the type of the option is a number or a string, the whole string after
+// "=" mark is a default value.
+// If the type of the option is an array, the string after "=" mark have to be
+// rounded by square brackets and separate the elements with commas, like
+// [elem1,elem2,elem3].
+// The element separator can be used other than a comma by put the separator
+// before the open square bracket, like :[elem1:elem2:elem3].
+// It's useful when some array elements include commas.
+//
+// NOTE: A default value of a string array option in a struct tag is [], like
+// `opt:"name=[]"`, it doesn't represent an array which contains only an empty
+// string but an empty array.
+// If you want to specify an array which contains only an empty string, write
+// nothing after "=" mark, like `opt:"name="`.
+//
+// Usage example:
+//
+//	type MyOptions struct {
+//	  FooBar bool     `opt:"foo-bar,f"`
+//	  Baz    int      `opt:"baz,b=99"`
+//	  Qux    string   `opt:"=XXX"`
+//	  Quux   []string `opt:"quux=/[A/B/C]"`
+//	  Corge  []int
+//	}
+//	options := MyOptions{}
+//
+//	osArgs := []string{
+//	  "--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+//	  "--Corge", "20", "--Corge=21",
+//	}
+//
+//	cmdParams, err := ParseFor(osArgs, &options)
+//	cmdParams      // [c1 c2]
+//	options.FooBar // true
+//	options.Baz    // 12
+//	options.Qux    // ABC
+//	options.Quux   // [A B C]
+//	options.Corge  // [20 21]
+func ParseFor(args []string, options any) ([]string, sabi.Err) {
+	v := reflect.ValueOf(options)
+	if v.Kind() != reflect.Ptr {
+		return empty, sabi.NewErr(OptionStoreIsNotChangeable{})
+	}
+	v = v.Elem()
+
+	t := v.Type()
+	n := t.NumField()
+
+	optCfgs := make([]OptCfg, n)
+	vsetMap := make(map[string]func([]string) sabi.Err)
+
+	var vset func([]string) sabi.Err
+	var name string
+	var err sabi.Err
+
+	for i := 0; i < n; i++ {
+		optCfgs[i], err = newOptCfg(t.Field(i))
+		if !err.IsOk() {
+			return empty, err
+		}
+		vset, err = newValueSetter(optCfgs[i].Name, v.Field(i))
+		if !err.IsOk() {
+			return empty, err
+		}
+		vsetMap[optCfgs[i].Name] = vset
+	}
+
+	a, err := ParseWith(args, optCfgs)
+	if !err.IsOk() {
+		return empty, err
+	}
+
+	for name, vset = range vsetMap {
+		err := vset(a.optParams[name])
+		if !err.IsOk() {
+			return empty, err
+		}
+	}
+
+	return a.cmdParams, sabi.Ok()
+}
+
+func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
+	opt := fld.Tag.Get("opt")
+	arr := strings.SplitN(opt, "=", 2)
+
+	names := strings.Split(arr[0], ",")
+
+	var name string
+	var aliases []string
+	if len(names) == 0 || len(names[0]) == 0 {
+		name = fld.Name
+		aliases = nil
+	} else {
+		name = names[0]
+		aliases = names[1:]
+	}
+
+	isArray := false
+	hasParam := true
+	switch fld.Type.Kind() {
+	case reflect.Slice | reflect.Array:
+		isArray = true
+	case reflect.Bool:
+		hasParam = false
+	}
+
+	var defaults []string
+	if len(arr) > 1 && hasParam {
+		def := arr[1]
+		n := len(def)
+		if !isArray {
+			defaults = []string{def}
+		} else if n > 1 && def[0] == '[' && def[n-1] == ']' {
+			defs := def[1 : n-1]
+			if len(defs) > 0 {
+				defaults = strings.Split(defs, ",")
+			} else {
+				defaults = empty
+			}
+		} else if n > 2 && def[1] == '[' && def[n-1] == ']' {
+			defs := def[2 : n-1]
+			if len(defs) > 0 {
+				defaults = strings.Split(defs, def[0:1])
+			} else {
+				defaults = empty
+			}
+		} else {
+			defaults = []string{def}
+		}
+	}
+
+	return OptCfg{
+		Name:     name,
+		Aliases:  aliases,
+		HasParam: hasParam,
+		IsArray:  isArray,
+		Default:  defaults,
+	}, sabi.Ok()
+}
+
+func newValueSetter(
+	name string,
+	fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	t := fld.Type()
+	switch t.Kind() {
+	case reflect.Bool:
+		return newBoolSetter(name, fld)
+	case reflect.Int:
+		return newIntSetter(name, fld, strconv.IntSize)
+	case reflect.Int8:
+		return newIntSetter(name, fld, 8)
+	case reflect.Int16:
+		return newIntSetter(name, fld, 16)
+	case reflect.Int32:
+		return newIntSetter(name, fld, 32)
+	case reflect.Int64:
+		return newIntSetter(name, fld, 64)
+	case reflect.Uint:
+		return newUintSetter(name, fld, strconv.IntSize)
+	case reflect.Uint8:
+		return newUintSetter(name, fld, 8)
+	case reflect.Uint16:
+		return newUintSetter(name, fld, 16)
+	case reflect.Uint32:
+		return newUintSetter(name, fld, 32)
+	case reflect.Uint64:
+		return newUintSetter(name, fld, 64)
+	case reflect.Float32:
+		return newFloatSetter(name, fld, 32)
+	case reflect.Float64:
+		return newFloatSetter(name, fld, 64)
+	case reflect.Array | reflect.Slice:
+		elm := t.Elem()
+		switch elm.Kind() {
+		case reflect.Int:
+			return newIntArraySetter(name, fld, strconv.IntSize)
+		case reflect.Int8:
+			return newIntArraySetter(name, fld, 8)
+		case reflect.Int16:
+			return newIntArraySetter(name, fld, 16)
+		case reflect.Int32:
+			return newIntArraySetter(name, fld, 32)
+		case reflect.Int64:
+			return newIntArraySetter(name, fld, 64)
+		case reflect.Uint:
+			return newUintArraySetter(name, fld, strconv.IntSize)
+		case reflect.Uint8:
+			return newUintArraySetter(name, fld, 8)
+		case reflect.Uint16:
+			return newUintArraySetter(name, fld, 16)
+		case reflect.Uint32:
+			return newUintArraySetter(name, fld, 32)
+		case reflect.Uint64:
+			return newUintArraySetter(name, fld, 64)
+		case reflect.Float32:
+			return newFloatArraySetter(name, fld, 32)
+		case reflect.Float64:
+			return newFloatArraySetter(name, fld, 64)
+		case reflect.String:
+			return newStringArraySetter(name, fld)
+		default:
+			return newIllegalOptionTypeErr(name, t)
+		}
+	case reflect.String:
+		return newStringSetter(name, fld)
+	default:
+		return newIllegalOptionTypeErr(name, t)
+	}
+}
+
+func newIllegalOptionTypeErr(
+	name string, t reflect.Type,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func([]string) sabi.Err {
+		return sabi.Ok()
+	}
+	r := IllegalOptionType{Field: name, Type: t}
+	return fn, sabi.NewErr(r)
+}
+
+func newBoolSetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s != nil {
+			fld.SetBool(true)
+		}
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newIntSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseInt(s[0], 0, bitSize)
+		if e != nil {
+			r := FailToParseInt{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetInt(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newUintSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseUint(s[0], 0, bitSize)
+		if e != nil {
+			r := FailToParseUint{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetUint(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newFloatSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseFloat(s[0], bitSize)
+		if e != nil {
+			r := FailToParseFloat{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetFloat(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newStringSetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		fld.SetString(s[0])
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newIntArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 {
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseInt(s[i], 0, bitSize)
+			if e != nil {
+				r := FailToParseInt{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newUintArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseUint(s[i], 0, bitSize)
+			if e != nil {
+				r := FailToParseUint{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newFloatArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseFloat(s[i], bitSize)
+			if e != nil {
+				r := FailToParseFloat{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newStringArraySetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			a[i] = reflect.ValueOf(s[i])
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}

--- a/libarg/parse-for_test.go
+++ b/libarg/parse-for_test.go
@@ -1,0 +1,1326 @@
+package libarg_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/clidax/libarg"
+	"reflect"
+	"testing"
+)
+
+func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
+	type MyOptions struct{}
+	args := []string{}
+	options := MyOptions{}
+	cmdParams, err := libarg.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+}
+
+func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
+	type MyOptions struct {
+		BoolVal    bool
+		IntVal     int
+		Int8Val    int8
+		Int16Val   int16
+		Int32Val   int32
+		Int64Val   int64
+		UintVal    uint
+		Uint8Val   uint8
+		Uint16Val  uint16
+		Uint32Val  uint32
+		Uint64Val  uint64
+		Float32Val float32
+		Float64Val float64
+		StringVal  string
+		IntArr     []int
+		Int8Arr    []int8
+		Int16Arr   []int16
+		Int32Arr   []int32
+		Int64Arr   []int64
+		UintArr    []uint
+		Uint8Arr   []uint8
+		Uint16Arr  []uint16
+		Uint32Arr  []uint32
+		Uint64Arr  []uint64
+		Float32Arr []float32
+		Float64Arr []float64
+		StringArr  []string
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	cmdParams, err := libarg.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+	assert.False(t, options.BoolVal)
+	assert.Equal(t, options.IntVal, 0)
+	assert.Equal(t, options.Int8Val, int8(0))
+	assert.Equal(t, options.Int16Val, int16(0))
+	assert.Equal(t, options.Int32Val, int32(0))
+	assert.Equal(t, options.Int64Val, int64(0))
+	assert.Equal(t, options.UintVal, uint(0))
+	assert.Equal(t, options.Uint8Val, uint8(0))
+	assert.Equal(t, options.Uint16Val, uint16(0))
+	assert.Equal(t, options.Uint32Val, uint32(0))
+	assert.Equal(t, options.Uint64Val, uint64(0))
+	assert.Equal(t, options.Float32Val, float32(0.0))
+	assert.Equal(t, options.Float64Val, 0.0)
+	assert.Equal(t, options.StringVal, "")
+	assert.Equal(t, options.IntArr, []int(nil))
+	assert.Equal(t, options.Int8Arr, []int8(nil))
+	assert.Equal(t, options.Int16Arr, []int16(nil))
+	assert.Equal(t, options.Int32Arr, []int32(nil))
+	assert.Equal(t, options.Int64Arr, []int64(nil))
+	assert.Equal(t, options.UintArr, []uint(nil))
+	assert.Equal(t, options.Uint8Arr, []uint8(nil))
+	assert.Equal(t, options.Uint16Arr, []uint16(nil))
+	assert.Equal(t, options.Uint32Arr, []uint32(nil))
+	assert.Equal(t, options.Uint64Arr, []uint64(nil))
+	assert.Equal(t, options.Float32Arr, []float32(nil))
+	assert.Equal(t, options.Float64Arr, []float64(nil))
+	assert.Equal(t, options.StringArr, []string(nil))
+}
+
+func TestParseFor_dontOverwriteOptionsIfNoArgs(t *testing.T) {
+	type MyOptions struct {
+		BoolVal    bool
+		IntVal     int
+		Int8Val    int8
+		Int16Val   int16
+		Int32Val   int32
+		Int64Val   int64
+		UintVal    uint
+		Uint8Val   uint8
+		Uint16Val  uint16
+		Uint32Val  uint32
+		Uint64Val  uint64
+		Float32Val float32
+		Float64Val float64
+		StringVal  string
+		IntArr     []int
+		Int8Arr    []int8
+		Int16Arr   []int16
+		Int32Arr   []int32
+		Int64Arr   []int64
+		UintArr    []uint
+		Uint8Arr   []uint8
+		Uint16Arr  []uint16
+		Uint32Arr  []uint32
+		Uint64Arr  []uint64
+		Float32Arr []float32
+		Float64Arr []float64
+		StringArr  []string
+	}
+	options := MyOptions{
+		BoolVal:    true,
+		IntVal:     111,
+		Int8Val:    22,
+		Int16Val:   333,
+		Int32Val:   444,
+		Int64Val:   555,
+		UintVal:    666,
+		Uint8Val:   77,
+		Uint16Val:  888,
+		Uint32Val:  999,
+		Uint64Val:  1111,
+		Float32Val: 0.123,
+		Float64Val: 0.456789,
+		StringVal:  "abcdefg",
+		IntArr:     []int{1, 1, 1},
+		Int8Arr:    []int8{2, 2},
+		Int16Arr:   []int16{3, 3, 3},
+		Int32Arr:   []int32{4, 4, 4},
+		Int64Arr:   []int64{5, 5, 5},
+		UintArr:    []uint{6, 6, 6},
+		Uint8Arr:   []uint8{7, 7},
+		Uint16Arr:  []uint16{8, 8, 8},
+		Uint32Arr:  []uint32{9, 9, 9},
+		Uint64Arr:  []uint64{1, 1, 1, 1},
+		Float32Arr: []float32{0.1, 2.3},
+		Float64Arr: []float64{0.45, 6.789},
+		StringArr:  []string{"ab", "cd", "efg"},
+	}
+
+	args := []string{}
+	cmdParams, err := libarg.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+	assert.True(t, options.BoolVal)
+	assert.Equal(t, options.IntVal, 111)
+	assert.Equal(t, options.Int8Val, int8(22))
+	assert.Equal(t, options.Int16Val, int16(333))
+	assert.Equal(t, options.Int32Val, int32(444))
+	assert.Equal(t, options.Int64Val, int64(555))
+	assert.Equal(t, options.UintVal, uint(666))
+	assert.Equal(t, options.Uint8Val, uint8(77))
+	assert.Equal(t, options.Uint16Val, uint16(888))
+	assert.Equal(t, options.Uint32Val, uint32(999))
+	assert.Equal(t, options.Uint64Val, uint64(1111))
+	assert.Equal(t, options.Float32Val, float32(0.123))
+	assert.Equal(t, options.Float64Val, 0.456789)
+	assert.Equal(t, options.StringVal, "abcdefg")
+	assert.Equal(t, options.IntArr, []int{1, 1, 1})
+	assert.Equal(t, options.Int8Arr, []int8{2, 2})
+	assert.Equal(t, options.Int16Arr, []int16{3, 3, 3})
+	assert.Equal(t, options.Int32Arr, []int32{4, 4, 4})
+	assert.Equal(t, options.Int64Arr, []int64{5, 5, 5})
+	assert.Equal(t, options.UintArr, []uint{6, 6, 6})
+	assert.Equal(t, options.Uint8Arr, []uint8{7, 7})
+	assert.Equal(t, options.Uint16Arr, []uint16{8, 8, 8})
+	assert.Equal(t, options.Uint32Arr, []uint32{9, 9, 9})
+	assert.Equal(t, options.Uint64Arr, []uint64{1, 1, 1, 1})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 2.3})
+	assert.Equal(t, options.Float64Arr, []float64{0.45, 6.789})
+	assert.Equal(t, options.StringArr, []string{"ab", "cd", "efg"})
+}
+
+func TestParseFor_optionIsBoolAndArgIsName(t *testing.T) {
+	type MyOptions struct {
+		Flag bool `opt:"flag,f"`
+	}
+	options := MyOptions{}
+
+	args := []string{"--flag", "abc"}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.True(t, options.Flag)
+}
+
+func TestParseFor_optionIsBoolAndArgIsAlias(t *testing.T) {
+	type MyOptions struct {
+		Flag bool `opt:"flag,f"`
+	}
+	options := MyOptions{}
+
+	args := []string{"-f", "abc"}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.True(t, options.Flag)
+}
+
+func TestParseFor_optionsAreIntAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"int-val,i"`
+		Int8Val  int8  `opt:"int8-val,j"`
+		Int16Val int16 `opt:"int16-val,k"`
+		Int32Val int32 `opt:"int32-val,m"`
+		Int64Val int64 `opt:"int64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--int-val", "1",
+		"--int8-val", "2",
+		"--int16-val", "3",
+		"--int32-val", "4",
+		"--int64-val", "5",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.IntVal, 1)
+	assert.Equal(t, options.Int8Val, int8(2))
+	assert.Equal(t, options.Int16Val, int16(3))
+	assert.Equal(t, options.Int32Val, int32(4))
+	assert.Equal(t, options.Int64Val, int64(5))
+}
+
+func TestParseFor_optionsAreIntAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"int-val,i"`
+		Int8Val  int8  `opt:"int8-val,j"`
+		Int16Val int16 `opt:"int16-val,k"`
+		Int32Val int32 `opt:"int32-val,m"`
+		Int64Val int64 `opt:"int64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-i", "1",
+		"-j", "2",
+		"-k", "3",
+		"-m", "4",
+		"-n", "5",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.IntVal, 1)
+	assert.Equal(t, options.Int8Val, int8(2))
+	assert.Equal(t, options.Int16Val, int16(3))
+	assert.Equal(t, options.Int32Val, int32(4))
+	assert.Equal(t, options.Int64Val, int64(5))
+}
+
+func TestParseFor_optionsAreUintAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"uint-val,i"`
+		Uint8Val  uint8  `opt:"uint8-val,j"`
+		Uint16Val uint16 `opt:"uint16-val,k"`
+		Uint32Val uint32 `opt:"uint32-val,m"`
+		Uint64Val uint64 `opt:"uint64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--uint-val", "1",
+		"--uint8-val", "2",
+		"--uint16-val", "3",
+		"--uint32-val", "4",
+		"--uint64-val", "5",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.UintVal, uint(1))
+	assert.Equal(t, options.Uint8Val, uint8(2))
+	assert.Equal(t, options.Uint16Val, uint16(3))
+	assert.Equal(t, options.Uint32Val, uint32(4))
+	assert.Equal(t, options.Uint64Val, uint64(5))
+}
+
+func TestParseFor_optionsAreUintAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"uint-val,i"`
+		Uint8Val  uint8  `opt:"uint8-val,j"`
+		Uint16Val uint16 `opt:"uint16-val,k"`
+		Uint32Val uint32 `opt:"uint32-val,m"`
+		Uint64Val uint64 `opt:"uint64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-i", "1",
+		"-j", "2",
+		"-k", "3",
+		"-m", "4",
+		"-n", "5",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.UintVal, uint(1))
+	assert.Equal(t, options.Uint8Val, uint8(2))
+	assert.Equal(t, options.Uint16Val, uint16(3))
+	assert.Equal(t, options.Uint32Val, uint32(4))
+	assert.Equal(t, options.Uint64Val, uint64(5))
+}
+
+func TestParseFor_optionsAreFloatAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"float32-val,m"`
+		Float64Val float64 `opt:"float64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--float32-val", "0.1234",
+		"--float64-val", "0.5678",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.Float32Val, float32(0.1234))
+	assert.Equal(t, options.Float64Val, 0.5678)
+}
+
+func TestParseFor_optionsAreFloatAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"float32-val,m"`
+		Float64Val float64 `opt:"float64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-m", "0.1234",
+		"-n", "0.5678",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.Float32Val, float32(0.1234))
+	assert.Equal(t, options.Float64Val, 0.5678)
+}
+
+func TestParseFor_optionsAreStringAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		StringVal string `opt:"string-val,s"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--string-val", "def",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.StringVal, "def")
+}
+
+func TestParseFor_optionsAreStringAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		StringVal string `opt:"string-val,s"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-s", "def",
+		"abc",
+	}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.StringVal, "def")
+}
+
+func TestParseFor_defaultValueIsInt(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"=11"`
+		Int8Val  int8  `opt:"=22"`
+		Int16Val int16 `opt:"=33"`
+		Int32Val int32 `opt:"=44"`
+		Int64Val int64 `opt:"=55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntVal, 11)
+	assert.Equal(t, options.Int8Val, int8(22))
+	assert.Equal(t, options.Int16Val, int16(33))
+	assert.Equal(t, options.Int32Val, int32(44))
+	assert.Equal(t, options.Int64Val, int64(55))
+}
+
+func TestParseFor_defaultValueIsNegativeInt(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"=-11"`
+		Int8Val  int8  `opt:"=-22"`
+		Int16Val int16 `opt:"=-33"`
+		Int32Val int32 `opt:"=-44"`
+		Int64Val int64 `opt:"=-55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntVal, -11)
+	assert.Equal(t, options.Int8Val, int8(-22))
+	assert.Equal(t, options.Int16Val, int16(-33))
+	assert.Equal(t, options.Int32Val, int32(-44))
+	assert.Equal(t, options.Int64Val, int64(-55))
+}
+
+func TestParseFor_defaultValueIsUint(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"=11"`
+		Uint8Val  uint8  `opt:"=22"`
+		Uint16Val uint16 `opt:"=33"`
+		Uint32Val uint32 `opt:"=44"`
+		Uint64Val uint64 `opt:"=55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintVal, uint(11))
+	assert.Equal(t, options.Uint8Val, uint8(22))
+	assert.Equal(t, options.Uint16Val, uint16(33))
+	assert.Equal(t, options.Uint32Val, uint32(44))
+	assert.Equal(t, options.Uint64Val, uint64(55))
+}
+
+func TestParseFor_defaultValueIsFloat(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"=0.123"`
+		Float64Val float64 `opt:"=0.456789"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Val, float32(0.123))
+	assert.Equal(t, options.Float64Val, float64(0.456789))
+}
+
+func TestParseFor_defaultValueIsNegativeFloat(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"=-0.123"`
+		Float64Val float64 `opt:"=-0.456789"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Val, float32(-0.123))
+	assert.Equal(t, options.Float64Val, float64(-0.456789))
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[]"`
+		Int8Arr  []int8  `opt:"=[]"`
+		Int16Arr []int16 `opt:"=[]"`
+		Int32Arr []int32 `opt:"=[]"`
+		Int64Arr []int64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{})
+	assert.Equal(t, options.Int8Arr, []int8{})
+	assert.Equal(t, options.Int16Arr, []int16{})
+	assert.Equal(t, options.Int32Arr, []int32{})
+	assert.Equal(t, options.Int64Arr, []int64{})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[]"`
+		Int8Arr  []int8  `opt:"=[]"`
+		Int16Arr []int16 `opt:"=[]"`
+		Int32Arr []int32 `opt:"=[]"`
+		Int64Arr []int64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{1},
+		Int8Arr:  []int8{2},
+		Int16Arr: []int16{3},
+		Int32Arr: []int32{4},
+		Int64Arr: []int64{5},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{})
+	assert.Equal(t, options.Int8Arr, []int8{})
+	assert.Equal(t, options.Int16Arr, []int16{})
+	assert.Equal(t, options.Int32Arr, []int32{})
+	assert.Equal(t, options.Int64Arr, []int64{})
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1]"`
+		Int8Arr  []int8  `opt:"=[2]"`
+		Int16Arr []int16 `opt:"=[3]"`
+		Int32Arr []int32 `opt:"=[4]"`
+		Int64Arr []int64 `opt:"=[5]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1})
+	assert.Equal(t, options.Int8Arr, []int8{2})
+	assert.Equal(t, options.Int16Arr, []int16{3})
+	assert.Equal(t, options.Int32Arr, []int32{4})
+	assert.Equal(t, options.Int64Arr, []int64{5})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1]"`
+		Int8Arr  []int8  `opt:"=[2]"`
+		Int16Arr []int16 `opt:"=[3]"`
+		Int32Arr []int32 `opt:"=[4]"`
+		Int64Arr []int64 `opt:"=[5]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{11},
+		Int8Arr:  []int8{22},
+		Int16Arr: []int16{33},
+		Int32Arr: []int32{44},
+		Int64Arr: []int64{55},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1})
+	assert.Equal(t, options.Int8Arr, []int8{2})
+	assert.Equal(t, options.Int16Arr, []int16{3})
+	assert.Equal(t, options.Int32Arr, []int32{4})
+	assert.Equal(t, options.Int64Arr, []int64{5})
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1,2]"`
+		Int8Arr  []int8  `opt:"=[2,3]"`
+		Int16Arr []int16 `opt:"=[3,4]"`
+		Int32Arr []int32 `opt:"=[4,5]"`
+		Int64Arr []int64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1, 2})
+	assert.Equal(t, options.Int8Arr, []int8{2, 3})
+	assert.Equal(t, options.Int16Arr, []int16{3, 4})
+	assert.Equal(t, options.Int32Arr, []int32{4, 5})
+	assert.Equal(t, options.Int64Arr, []int64{5, 6})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1,2]"`
+		Int8Arr  []int8  `opt:"=[2,3]"`
+		Int16Arr []int16 `opt:"=[3,4]"`
+		Int32Arr []int32 `opt:"=[4,5]"`
+		Int64Arr []int64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{11},
+		Int8Arr:  []int8{22},
+		Int16Arr: []int16{33},
+		Int32Arr: []int32{44},
+		Int64Arr: []int64{55},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1, 2})
+	assert.Equal(t, options.Int8Arr, []int8{2, 3})
+	assert.Equal(t, options.Int16Arr, []int16{3, 4})
+	assert.Equal(t, options.Int32Arr, []int32{4, 5})
+	assert.Equal(t, options.Int64Arr, []int64{5, 6})
+}
+
+func TestParseFor_defaultValueIsNegativeIntArray(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[-1,-2]"`
+		Int8Arr  []int8  `opt:"=[-2,-3]"`
+		Int16Arr []int16 `opt:"=[-3,-4]"`
+		Int32Arr []int32 `opt:"=[-4,-5]"`
+		Int64Arr []int64 `opt:"=[-5,-6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{-1, -2})
+	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
+	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
+	assert.Equal(t, options.Int32Arr, []int32{-4, -5})
+	assert.Equal(t, options.Int64Arr, []int64{-5, -6})
+}
+
+func TestParseFor_defaultValueIsIntArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=:[-1:-2]"`
+		Int8Arr  []int8  `opt:"=/[-2/-3]"`
+		Int16Arr []int16 `opt:"=![-3!-4]"`
+		Int32Arr []int32 `opt:"=|[-4|-5]"`
+		Int64Arr []int64 `opt:"='[-5'-6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{-1, -2})
+	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
+	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
+	assert.Equal(t, options.Int32Arr, []int32{-4, -5})
+	assert.Equal(t, options.Int64Arr, []int64{-5, -6})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[]"`
+		Uint8Arr  []uint8  `opt:"=[]"`
+		Uint16Arr []uint16 `opt:"=[]"`
+		Uint32Arr []uint32 `opt:"=[]"`
+		Uint64Arr []uint64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{})
+	assert.Equal(t, options.Uint8Arr, []uint8{})
+	assert.Equal(t, options.Uint16Arr, []uint16{})
+	assert.Equal(t, options.Uint32Arr, []uint32{})
+	assert.Equal(t, options.Uint64Arr, []uint64{})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[]"`
+		Uint8Arr  []uint8  `opt:"=[]"`
+		Uint16Arr []uint16 `opt:"=[]"`
+		Uint32Arr []uint32 `opt:"=[]"`
+		Uint64Arr []uint64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{1},
+		Uint8Arr:  []uint8{2},
+		Uint16Arr: []uint16{3},
+		Uint32Arr: []uint32{4},
+		Uint64Arr: []uint64{5},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{})
+	assert.Equal(t, options.Uint8Arr, []uint8{})
+	assert.Equal(t, options.Uint16Arr, []uint16{})
+	assert.Equal(t, options.Uint32Arr, []uint32{})
+	assert.Equal(t, options.Uint64Arr, []uint64{})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1]"`
+		Uint8Arr  []uint8  `opt:"=[2]"`
+		Uint16Arr []uint16 `opt:"=[3]"`
+		Uint32Arr []uint32 `opt:"=[4]"`
+		Uint64Arr []uint64 `opt:"=[5]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1})
+	assert.Equal(t, options.Uint8Arr, []uint8{2})
+	assert.Equal(t, options.Uint16Arr, []uint16{3})
+	assert.Equal(t, options.Uint32Arr, []uint32{4})
+	assert.Equal(t, options.Uint64Arr, []uint64{5})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1]"`
+		Uint8Arr  []uint8  `opt:"=[2]"`
+		Uint16Arr []uint16 `opt:"=[3]"`
+		Uint32Arr []uint32 `opt:"=[4]"`
+		Uint64Arr []uint64 `opt:"=[5]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{11},
+		Uint8Arr:  []uint8{22},
+		Uint16Arr: []uint16{33},
+		Uint32Arr: []uint32{44},
+		Uint64Arr: []uint64{55},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1})
+	assert.Equal(t, options.Uint8Arr, []uint8{2})
+	assert.Equal(t, options.Uint16Arr, []uint16{3})
+	assert.Equal(t, options.Uint32Arr, []uint32{4})
+	assert.Equal(t, options.Uint64Arr, []uint64{5})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1,2]"`
+		Uint8Arr  []uint8  `opt:"=[2,3]"`
+		Uint16Arr []uint16 `opt:"=[3,4]"`
+		Uint32Arr []uint32 `opt:"=[4,5]"`
+		Uint64Arr []uint64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1,2]"`
+		Uint8Arr  []uint8  `opt:"=[2,3]"`
+		Uint16Arr []uint16 `opt:"=[3,4]"`
+		Uint32Arr []uint32 `opt:"=[4,5]"`
+		Uint64Arr []uint64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{11},
+		Uint8Arr:  []uint8{22},
+		Uint16Arr: []uint16{33},
+		Uint32Arr: []uint32{44},
+		Uint64Arr: []uint64{55},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_defaultValueIsUintArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=:[1:2]"`
+		Uint8Arr  []uint8  `opt:"=/[2/3]"`
+		Uint16Arr []uint16 `opt:"=![3!4]"`
+		Uint32Arr []uint32 `opt:"=|[4|5]"`
+		Uint64Arr []uint64 `opt:"='[5'6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[]"`
+		Float64Arr []float64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{})
+	assert.Equal(t, options.Float64Arr, []float64{})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[]"`
+		Float64Arr []float64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.999},
+		Float64Arr: []float64{0.888},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{})
+	assert.Equal(t, options.Float64Arr, []float64{})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1]"`
+		Float64Arr []float64 `opt:"=[0.2]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1})
+	assert.Equal(t, options.Float64Arr, []float64{0.2})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1]"`
+		Float64Arr []float64 `opt:"=[0.2]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.99},
+		Float64Arr: []float64{0.88},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1})
+	assert.Equal(t, options.Float64Arr, []float64{0.2})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1,0.2]"`
+		Float64Arr []float64 `opt:"=[0.3,0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
+	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1,0.2]"`
+		Float64Arr []float64 `opt:"=[0.3,0.4]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.99},
+		Float64Arr: []float64{0.88},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
+	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
+}
+
+func TestParseFor_defaultValueIsNegativeFloatArray(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[-0.1,-0.2]"`
+		Float64Arr []float64 `opt:"=[-0.3,-0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
+	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
+}
+
+func TestParseFor_defaultValueIsFloatArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=|[-0.1|-0.2]"`
+		Float64Arr []float64 `opt:"='[-0.3'-0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
+	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
+}
+
+func TestParseFor_defaultValueIsStringAndSize0(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{})
+}
+
+func TestParseFor_defaultValueIsStringArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC"})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC"})
+}
+
+func TestParseFor_defaultValueIsStringArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC,DEF]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC,DEF]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_defaultValueIsStringArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=|[ABC|DEF]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
+	type MyOptions struct {
+		BoolVar bool `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.False(t, options.BoolVar)
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
+	type MyOptions struct {
+		IntVar int `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseInt:
+		assert.Equal(t, err.Get("Field"), "IntVar")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
+	type MyOptions struct {
+		UintVar uint `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseUint:
+		assert.Equal(t, err.Get("Field"), "UintVar")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
+	type MyOptions struct {
+		Float64Var float64 `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseFloat:
+		assert.Equal(t, err.Get("Field"), "Float64Var")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
+	type MyOptions struct {
+		StringVar string `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringVar, "")
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
+	type MyOptions struct {
+		IntArr []int `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseInt:
+		assert.Equal(t, err.Get("Field"), "IntArr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
+	type MyOptions struct {
+		UintArr []uint `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseUint:
+		assert.Equal(t, err.Get("Field"), "UintArr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
+	type MyOptions struct {
+		Float64Arr []float64 `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.FailToParseFloat:
+		assert.Equal(t, err.Get("Field"), "Float64Arr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_optionIsStringArrayAndSetOneEmptyStringByDefaultArray(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"str-arr="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{""})
+}
+
+func TestParseFor_defaultValueIsIgnoreWhenTypeIsBool(t *testing.T) {
+	type MyOptions struct {
+		BoolVar bool `opt:"bool-var=true"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.False(t, options.BoolVar)
+}
+
+func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
+	type MyOptions struct {
+		BoolArr []bool
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := libarg.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case libarg.IllegalOptionType:
+		assert.Equal(t, err.Get("Field"), "BoolArr")
+		assert.Equal(t, err.Get("Type"), reflect.TypeOf(options.BoolArr))
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_multipleOptsAndMultipleArgs(t *testing.T) {
+	type MyOptions struct {
+		FooBar bool     `opt:"foo-bar,f"`
+		Baz    int      `opt:"baz,b=99"`
+		Qux    string   `opt:"=XXX"`
+		Quux   []string `opt:"quux=/[A/B/C]"`
+		Corge  []int
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+		"--Corge", "20", "--Corge=21",
+	}
+
+	cmdParams, err := libarg.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{"c1", "c2"})
+	assert.True(t, options.FooBar)
+	assert.Equal(t, options.Baz, 12)
+	assert.Equal(t, options.Qux, "ABC")
+	assert.Equal(t, options.Quux, []string{"A", "B", "C"})
+	assert.Equal(t, options.Corge, []int{20, 21})
+}

--- a/libarg/parse-with.go
+++ b/libarg/parse-with.go
@@ -99,7 +99,7 @@ type OptCfg struct {
 //	optCfgs := []OptCfg{
 //		OptCfg{Name:"foo-bar"},
 //		OptCfg{Name:"baz", Aliases:[]string{"z"}, HasParam:true, IsArray:true},
-//		OptCfg{Name:"corge", Default:[]string{"99"}},
+//		OptCfg{Name:"corge", HasParam:true, Default:[]string{"99"}},
 //		OptCfg{Name:"*"},
 //	}
 //

--- a/libarg/parse-with_test.go
+++ b/libarg/parse-with_test.go
@@ -802,7 +802,6 @@ func TestParseWith_multipleArgs(t *testing.T) {
 	}
 
 	args, err := libarg.ParseWith(osArgs, optCfgs)
-	t.Logf(err.Error())
 	assert.True(t, err.IsOk())
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.True(t, args.HasOpt("baz"))

--- a/libarg/parse.go
+++ b/libarg/parse.go
@@ -18,7 +18,6 @@ type /* error reason */ (
 )
 
 var (
-	//noentry []string = nil
 	empty            = make([]string, 0)
 	rangeOfAlphabets = &unicode.RangeTable{
 		R16: []unicode.Range16{


### PR DESCRIPTION
### Changes:

1. [comment: modified usage sample of ParseWith](https://github.com/sttk-go/clidax/commit/7934423d93e70a328ef6bac8308f17d01294b4ec)

    This modification fixes a mistake of usage sample in godoc comment for `ParseWith` function.

2. [test: removed a console output for debug](https://github.com/sttk-go/clidax/commit/cdf4a3a01909f46c61295a382f22c5289acc283f)

    This modification erases a forgotten console output for debug in test code.

4. [comment: removed an unnecessary comment](https://github.com/sttk-go/clidax/commit/6b970bd3461d3a7d794ca12c2e2bdc17b4e53aea)

    This modification erase an unnecessary comment. This comment was what I would use in `ParseFor` implementation, but I didn't use it.

5. [new: added a new function: ParseFor](https://github.com/sttk-go/clidax/commit/812fb448e97b1865cf1b1c4c90c5fe682c2c5600)

    This modification is the main of this PR. `ParseFor` is a function which receives an option store as the second parameter, parses command line arguments according with the option store's field types and struct tags, and set the results to the option store's fields.