### PR TITLE
new: added .OnParsed field to OptCfg and MakeOptCfgsFor function

### DIFF
--- a/libarg/parse-for.go
+++ b/libarg/parse-for.go
@@ -129,10 +129,6 @@ func ParseFor(args []string, options any) ([]string, sabi.Err) {
 	n := t.NumField()
 
 	optCfgs := make([]OptCfg, n)
-	vsetMap := make(map[string]func([]string) sabi.Err)
-
-	var vset func([]string) sabi.Err
-	var name string
 	var err sabi.Err
 
 	for i := 0; i < n; i++ {
@@ -140,23 +136,17 @@ func ParseFor(args []string, options any) ([]string, sabi.Err) {
 		if !err.IsOk() {
 			return empty, err
 		}
-		vset, err = newValueSetter(optCfgs[i].Name, v.Field(i))
+		var setter func([]string) sabi.Err
+		setter, err = newValueSetter(optCfgs[i].Name, v.Field(i))
 		if !err.IsOk() {
 			return empty, err
 		}
-		vsetMap[optCfgs[i].Name] = vset
+		optCfgs[i].OnParsed = &setter
 	}
 
 	a, err := ParseWith(args, optCfgs)
 	if !err.IsOk() {
 		return empty, err
-	}
-
-	for name, vset = range vsetMap {
-		err := vset(a.optParams[name])
-		if !err.IsOk() {
-			return empty, err
-		}
 	}
 
 	return a.cmdParams, sabi.Ok()


### PR DESCRIPTION
## Changes:

1. [new: added .OnParsed field to OptCfg](https://github.com/sttk-go/clidax/commit/779978407f4b85295b7cf42c62fc6ebbb4888e1b)

    This modification adds `OptCfg.OnParsed` event handler which is called when the option has been parsed.
    In addition, this modification changes to use this event handler for setting field's value of an option store in `ParseFor` function.

2. [new: added MakeOptCfgsFor function](https://github.com/sttk-go/clidax/commit/a1c7dc347fbf46c94f146a32a778713e29f5d9db)

    This modification divides `ParseFor` function to the combination of `MakeOptCfgsFor`function and `ParseWith` function.
    `MakeOptCfgsFor` makes a `OptCfg` array from an option store which is the arguments of `ParseFor`.